### PR TITLE
Add LISIRD HAPI server

### DIFF
--- a/all.txt
+++ b/all.txt
@@ -4,3 +4,4 @@ http://datashop.elasticbeanstalk.com/hapi
 https://cdaweb.gsfc.nasa.gov/hapi
 http://planet.physics.uiowa.edu/das/das2Server/hapi
 https://iswa.gsfc.nasa.gov/IswaSystemWebApp/hapi
+http://lasp.colorado.edu/lisird/hapi

--- a/server_list.txt
+++ b/server_list.txt
@@ -4,3 +4,4 @@ http://datashop.elasticbeanstalk.com/hapi
 https://cdaweb.gsfc.nasa.gov/hapi
 http://planet.physics.uiowa.edu/das/das2Server/hapi
 https://iswa.gsfc.nasa.gov/IswaSystemWebApp/hapi
+http://lasp.colorado.edu/lisird/hapi


### PR DESCRIPTION
We're working on providing access to our LISIRD catalog through [our HAPI server implementation](https://github.com/lasp/hapi-server).

We're currently only serving a subset of our more popular datasets, but we plan to have them all available through HAPI in March.